### PR TITLE
Add 0.5 to predicted coordinates and improve Python 3 compatibility

### DIFF
--- a/pose/utils/evaluation.py
+++ b/pose/utils/evaluation.py
@@ -83,6 +83,7 @@ def final_preds(output, center, scale, res):
             if px > 1 and px < res[0] and py > 1 and py < res[1]:
                 diff = torch.Tensor([hm[py - 1][px] - hm[py - 1][px - 2], hm[py][px - 1]-hm[py - 2][px - 1]])
                 coords[n][p] += diff.sign() * .25
+    coords += 0.5
     preds = coords.clone()
 
     # Transform back

--- a/pose/utils/imutils.py
+++ b/pose/utils/imutils.py
@@ -135,7 +135,7 @@ def sample_with_heatmap(inp, out, num_rows=2, parts_to_show=None):
     out = to_numpy(out)
 
     img = np.zeros((inp.shape[1], inp.shape[2], inp.shape[0]))
-    for i in xrange(3):
+    for i in range(3):
         img[:, :, i] = inp[i, :, :]
 
     if parts_to_show is None:
@@ -143,7 +143,7 @@ def sample_with_heatmap(inp, out, num_rows=2, parts_to_show=None):
 
     # Generate a single image to display input/output pair
     num_cols = int(np.ceil(float(len(parts_to_show)) / num_rows))
-    size = img.shape[0] / num_rows
+    size = img.shape[0] // num_rows
 
     full_img = np.zeros((img.shape[0], size * (num_cols + num_rows), 3), np.uint8)
     full_img[:img.shape[0], :img.shape[1]] = img


### PR DESCRIPTION
In the official implementation, all predicted coordinates are shifted by [0.5 pixel](https://github.com/anewell/pose-hg-train/blob/master/src/util/pose.lua#L97), which was explained [here](https://github.com/anewell/pose-hg-train/issues/16#issuecomment-274289122).

In my setting, PCKh gets improved from 86.68 to 86.99 (+0.31) with the trick.