### PR TITLE
change MSElLoss attribute

### DIFF
--- a/pose/losses/jointsmseloss.py
+++ b/pose/losses/jointsmseloss.py
@@ -15,7 +15,7 @@ import torch.nn as nn
 class JointsMSELoss(nn.Module):
     def __init__(self, use_target_weight=True):
         super(JointsMSELoss, self).__init__()
-        self.criterion = nn.MSELoss(reduction='mean')
+        self.criterion = nn.MSELoss(reduction='elementwise_mean')
         self.use_target_weight = use_target_weight
 
     def forward(self, output, target, target_weight):


### PR DESCRIPTION
The current value of reduction is "mean", which is not supported by pytorch (in my case pytoch 0.4.1, python version 3). When changing it to "elementwise_mean" the interpreter dosen't complain.