### PR TITLE
fix cv2.resize dsize order

### DIFF
--- a/pose/utils/transforms.py
+++ b/pose/utils/transforms.py
@@ -128,7 +128,7 @@ def transform_preds(coords, center, scale, res):
 
 def crop(img, center, scale, res, rot=0):
     img = im_to_numpy(img)
-  
+
     # Preprocessing for efficient cropping
     ht, wd = img.shape[0], img.shape[1]
     sf = scale * 200.0 / res[0]
@@ -142,18 +142,15 @@ def crop(img, center, scale, res, rot=0):
             return torch.zeros(res[0], res[1], img.shape[2]) \
                         if len(img.shape) > 2 else torch.zeros(res[0], res[1])
         else:
-             img= cv2.resize(img, dsize=(new_ht,new_wd), interpolation=cv2.INTER_LINEAR)
-             print("after resize()",new_ht,new_wd)
-             
-#img = imresize(img, [new_ht, new_wd])
-             center = center * 1.0 / sf
-             scale = scale / sf
+            img = cv2.resize(img, dsize=(new_wd, new_ht), interpolation=cv2.INTER_LINEAR)
+            center = center * 1.0 / sf
+            scale = scale / sf
 
     # Upper left point
     ul = np.array(transform([0, 0], center, scale, res, invert=1))
     # Bottom right point
     br = np.array(transform(res, center, scale, res, invert=1))
-   
+
     # Padding so that when rotated proper amount of context is included
     pad = int(np.linalg.norm(br - ul) / 2 - float(br[1] - ul[1]) / 2)
     if not rot == 0:
@@ -161,7 +158,6 @@ def crop(img, center, scale, res, rot=0):
         br += pad
 
     new_shape = [br[1] - ul[1], br[0] - ul[0]]
-   
     if len(img.shape) > 2:
         new_shape += [img.shape[2]]
     new_img = np.zeros(new_shape)
@@ -170,31 +166,23 @@ def crop(img, center, scale, res, rot=0):
     new_x = [max(0, -ul[0]), min(br[0], img.shape[1]) - ul[0]]
     new_y = [max(0, -ul[1]), min(br[1], img.shape[0]) - ul[1]]
     # Range to sample from original image
-    
-    
     old_x = [max(0, ul[0]), min(img.shape[1], br[0])]
     old_y = [max(0, ul[1]), min(img.shape[0], br[1])]
-    
-    
-    if(new_x[1]<new_x[0]):
-        tmp= new_x[1];
-        new_x[1]=new_x[0]
-        new_x[0]=tmp
-        tmp=old_x[0]
-        old_x[0]=old_x[1]
-        old_x[1]=tmp
+    if new_x[1] < new_x[0]:
+        tmp = new_x[1]
+        new_x[1] = new_x[0]
+        new_x[0] = tmp
+        tmp = old_x[0]
+        old_x[0] = old_x[1]
+        old_x[1] = tmp
         # swapping the upper-left and bottom right point if upper-left goes out of image
-        
-
 
     new_img[new_y[0]:new_y[1], new_x[0]:new_x[1]] = img[old_y[0]:old_y[1], old_x[0]:old_x[1]]
 
     if not rot == 0:
         # Remove padding
-        #new_img = imrotate(new_img, rot)
         new_img= imutils.rotate_bound(new_img,rot)
         new_img = new_img[pad:-pad, pad:-pad]
 
     new_img = im_to_torch(cv2.resize(new_img, dsize=(res[0],res[1]), interpolation=cv2.INTER_LINEAR))
-        #scipy.misc.imresize(new_img, res)
     return new_img


### PR DESCRIPTION
In the last merge, the cv2.resize is not used properly.
The order of the dsize should be (width, height).
demo:
```
>>> import cv2
>>> import numpy as np
>>> img = np.ones([128, 128, 3])
>>> new_img = cv2.resize(img, (128, 256))
>>> new_img.shape
(256, 128, 3)
```