### PR TITLE
Fixed resize, rotate bugs in crop method

### DIFF
--- a/pose/utils/transforms.py
+++ b/pose/utils/transforms.py
@@ -142,10 +142,8 @@ def crop(img, center, scale, res, rot=0):
             return torch.zeros(res[0], res[1], img.shape[2]) \
                         if len(img.shape) > 2 else torch.zeros(res[0], res[1])
         else:
+             #img = imresize(img, [new_ht, new_wd])
              img= cv2.resize(img, dsize=(new_wd,new_ht), interpolation=cv2.INTER_LINEAR)
-             print("after resize()",new_ht,new_wd)
-             
-#img = imresize(img, [new_ht, new_wd])
              center = center * 1.0 / sf
              scale = scale / sf
 
@@ -192,9 +190,8 @@ def crop(img, center, scale, res, rot=0):
     if not rot == 0:
         # Remove padding
         #new_img = imrotate(new_img, rot)
-        
-        #new_img= imutils.rotate(new_img,rot) 
-        new_img= imutils.rotate_bound(new_img,-rot) #For bounded rotation
+        #new_img= imutils.rotate_bound(new_img,-rot) #For bounded rotation
+        new_img= imutils.rotate(new_img,rot) 
         new_img = new_img[pad:-pad, pad:-pad]
 
     new_img = im_to_torch(cv2.resize(new_img, dsize=(res[0],res[1]), interpolation=cv2.INTER_LINEAR))

--- a/pose/utils/transforms.py
+++ b/pose/utils/transforms.py
@@ -142,7 +142,7 @@ def crop(img, center, scale, res, rot=0):
             return torch.zeros(res[0], res[1], img.shape[2]) \
                         if len(img.shape) > 2 else torch.zeros(res[0], res[1])
         else:
-             img= cv2.resize(img, dsize=(new_ht,new_wd), interpolation=cv2.INTER_LINEAR)
+             img= cv2.resize(img, dsize=(new_wd,new_ht), interpolation=cv2.INTER_LINEAR)
              print("after resize()",new_ht,new_wd)
              
 #img = imresize(img, [new_ht, new_wd])
@@ -192,7 +192,7 @@ def crop(img, center, scale, res, rot=0):
     if not rot == 0:
         # Remove padding
         #new_img = imrotate(new_img, rot)
-        new_img= imutils.rotate_bound(new_img,rot)
+        new_img= imutils.rotate(new_img,rot) #_bound
         new_img = new_img[pad:-pad, pad:-pad]
 
     new_img = im_to_torch(cv2.resize(new_img, dsize=(res[0],res[1]), interpolation=cv2.INTER_LINEAR))

--- a/pose/utils/transforms.py
+++ b/pose/utils/transforms.py
@@ -192,7 +192,9 @@ def crop(img, center, scale, res, rot=0):
     if not rot == 0:
         # Remove padding
         #new_img = imrotate(new_img, rot)
-        new_img= imutils.rotate(new_img,rot) #_bound
+        
+        #new_img= imutils.rotate(new_img,rot) 
+        new_img= imutils.rotate_bound(new_img,-rot) #For bounded rotation
         new_img = new_img[pad:-pad, pad:-pad]
 
     new_img = im_to_torch(cv2.resize(new_img, dsize=(res[0],res[1]), interpolation=cv2.INTER_LINEAR))


### PR DESCRIPTION
The `cv2.resize` method requires dsize to be (width, height) as suggested by #116. Moreover, `imutils.rotate_bound` rotates the image clockwise, thus requiring `angle=-rot`, on the other hand `imutils.rotate` rotates the image anti-clockwise, thus requiring `angle=rot`