### PR TITLE
Minor bug fix in _make_fc function

### DIFF
--- a/pose/models/hourglass.py
+++ b/pose/models/hourglass.py
@@ -145,7 +145,7 @@ class HourglassNet(nn.Module):
         return nn.Sequential(*layers)
 
     def _make_fc(self, inplanes, outplanes):
-        bn = nn.BatchNorm2d(inplanes)
+        bn = nn.BatchNorm2d(outplanes)
         conv = nn.Conv2d(inplanes, outplanes, kernel_size=1, bias=True)
         return nn.Sequential(
                 conv,

--- a/pose/models/hourglass_gn.py
+++ b/pose/models/hourglass_gn.py
@@ -148,7 +148,7 @@ class HourglassNet(nn.Module):
         return nn.Sequential(*layers)
 
     def _make_fc(self, inplanes, outplanes):
-        bn = nn.GroupNorm(gn, inplanes)
+        bn = nn.GroupNorm(gn, outplanes)
         conv = nn.Conv2d(inplanes, outplanes, kernel_size=1, bias=True)
         return nn.Sequential(
                 conv,


### PR DESCRIPTION
function `_make_fc` gets parameters `inplanes` and `outplanes`
the conv layer inside `_make_fc` is followed by bn
because the input channels of bn must match with the output channels of conv layer,
parameter of bn should be changed from `inplanes` to `outplanes`
it did not cause any error because `_make_fc` is always used with same value of `inplanes` and `outplanes`
even so, I think it should be fixed


